### PR TITLE
Added 'capAdd' in HostConfig

### DIFF
--- a/rx-docker-client/src/main/java/com/shekhargulati/reactivex/docker/client/representations/HostConfig.java
+++ b/rx-docker-client/src/main/java/com/shekhargulati/reactivex/docker/client/representations/HostConfig.java
@@ -65,6 +65,8 @@ public class HostConfig {
     private String cpusetCpus;
     @SerializedName("CgroupParent")
     private String cgroupParent;
+    @SerializedName("CapAdd")
+    private List<String> capAdd;
 
     HostConfig(HostConfigBuilder builder) {
         this.binds = builder.binds;
@@ -84,6 +86,7 @@ public class HostConfig {
         this.cpuShares = builder.cpuShares;
         this.cpusetCpus = builder.cpusetCpus;
         this.cgroupParent = builder.cgroupParent;
+        this.capAdd = builder.capAdd;
     }
 
     public List<String> getBinds() {
@@ -152,6 +155,10 @@ public class HostConfig {
 
     public String getCgroupParent() {
         return cgroupParent;
+    }
+
+    public List<String> getCapAdd() {
+        return capAdd;
     }
 
     public static class LxcConfParameter {

--- a/rx-docker-client/src/main/java/com/shekhargulati/reactivex/docker/client/representations/HostConfigBuilder.java
+++ b/rx-docker-client/src/main/java/com/shekhargulati/reactivex/docker/client/representations/HostConfigBuilder.java
@@ -45,6 +45,7 @@ public class HostConfigBuilder {
     Long cpuShares;
     String cpusetCpus;
     String cgroupParent;
+    List<String> capAdd;
 
     public HostConfigBuilder setBinds(List<String> binds) {
         this.binds = binds;
@@ -128,6 +129,11 @@ public class HostConfigBuilder {
 
     public HostConfigBuilder setCgroupParent(String cgroupParent) {
         this.cgroupParent = cgroupParent;
+        return this;
+    }
+
+    public HostConfigBuilder setCapAdd(List<String> capAdd) {
+        this.capAdd = capAdd;
         return this;
     }
 


### PR DESCRIPTION
I wanna use tc command in the container, to mock some network failures.

for example:
```
tc qdisc add dev eth0 root netem delay 900ms
```

but we will got 
```
[root@swiftserver1 /]# tc qdisc add dev eth0 root netem delay 900ms
RTNETLINK answers: Operation not permitted
```

We must start the container with <code>--cap-add=NET_ADMIN</code>

In docker remote API:

```

{
...
       "HostConfig": {
...
         "CapAdd": ["NET_ADMIN"],
...
      }
  }
```

